### PR TITLE
Added group for restrict visibility on validate button on account_move

### DIFF
--- a/account_default_draft_move/__openerp__.py
+++ b/account_default_draft_move/__openerp__.py
@@ -52,6 +52,7 @@ need to make a refund).
     'data': ['account_view.xml',
              'invoice_view.xml',
              'res_config_view.xml',
+             'security/security_groups.xml',
              ],
     'installable': True,
     'active': False,

--- a/account_default_draft_move/account_view.xml
+++ b/account_default_draft_move/account_view.xml
@@ -7,7 +7,9 @@
       <field name="inherit_id" ref="account.view_move_form"/>
       <field name="arch" type="xml">
         <data>
-          <button name="button_validate" position="replace"/>
+          <button name="button_validate" position="replace">
+            <button name="button_validate" states="draft" string="Post" type="object" class="oe_highlight" groups="account_default_draft_move.group_validate_draft_move"/>
+          </button>
           <button name="button_cancel" position="after">
             <field name="update_posted" invisible="1"/>
           </button>

--- a/account_default_draft_move/security/security_groups.xml
+++ b/account_default_draft_move/security/security_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data noupdate="0">
+        <record id="group_validate_draft_move" model="res.groups">
+            <field name="name">Validate draft moves</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
In some workflows the accountant needs to validate each one of the
accounts_moves as soon as reviewe the move. That simplifies the
control for the review process
This commit adds a group for allow Validate button to be visible
for some users only
