### PR TITLE
fix(account.invoice.currency): se modifica el archivo __openerp__.py

### DIFF
--- a/account_invoice_currency/__openerp__.py
+++ b/account_invoice_currency/__openerp__.py
@@ -18,5 +18,5 @@
     'data': [
         "views/account_invoice_view.xml"
     ],
-    'installable': False,
+    'installable': True,
 }


### PR DESCRIPTION
Se cambia a installable `True` ya que a la hora de actualizar la base de datos manda errores de que
no existen algunos campos de este módulo